### PR TITLE
#14 Routing Number Summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ x9 is under active development, and should not be used in Production.  Please st
 	* Image Views
 
 * Future Development
-    * Increase Test Code Coverage to 95% +
     * Add additional property validations as necessary based on testing
-    * Add Routing Number Summary Tests
-    * Add Credit Items Functionality
     * Add User Record Functionality
     * Benchmarking and Profiling Tests
 

--- a/bundle.go
+++ b/bundle.go
@@ -30,7 +30,7 @@ const (
 	ReturnDetailAddendumDCount = 99
 )
 
-// Errors specific to parsing a Batch container
+// Errors specific to parsing a Bundle
 var (
 	msgBundleEntries       = "must have Check Detail or Return Detail to be built"
 	msgBundleAddendum      = "%v found is greater than maximum of %v"

--- a/cashLetterHeader.go
+++ b/cashLetterHeader.go
@@ -84,7 +84,7 @@ type CashLetterHeader struct {
 	// hh '00' through '23'
 	// mm '00' through '59'
 	CashLetterCreationTime time.Time `json:"cashLetterCreationTime"`
-	// CashLetterRecordTypeIndicator is a code that indicates the presence of records or the type of records contained
+	// RecordTypeIndicator is a code that indicates the presence of records or the type of records contained
 	// in the cash letter.   If an image is associated with any CheckDetail or Return, the cash letter must have a
 	// CashLetter.RecordTypeIndicator of I or F.
 	// Values:
@@ -98,8 +98,8 @@ type CashLetterHeader struct {
 	// with CollectionTypeIndicator values of 01, 02 or 03. ItemsCount and TotalAmount of the CashLetterControl with
 	// a RecordTypeIndicator value of F must equal the corresponding fields in a CashLetter with a RecordTypeIndicator
 	// value of E.
-	CashLetterRecordTypeIndicator string `json:"cashLetterRecordTypeIndicator"`
-	// CashLetterDocumentationTypeIndicator is a code that indicates the type of documentation that supports
+	RecordTypeIndicator string `json:"recordTypeIndicator"`
+	// DocumentationTypeIndicator is a code that indicates the type of documentation that supports
 	// all check records in the cash letter
 	// Values:
 	// A: No image provided, paper provided separately
@@ -117,7 +117,7 @@ type CashLetterHeader struct {
 	// M: No image provided, Electronic Check provided separately
 	// Z: Not Same Type–Documentation associated with each item in Cash Letter will be different. The Check Detail
 	// Record (Type 25) or Return Record (Type 31) has to be interrogated for further information.
-	CashLetterDocumentationTypeIndicator string `json:"cashLetterDocumentationTypeIndicator"`
+	DocumentationTypeIndicator string `json:"DocumentationTypeIndicator"`
 	// CashLetterID uniquely identifies the cash letter. It is assigned by the institution that creates the cash
 	// letter and must be unique within a Cash Letter Business Date.
 	CashLetterID string `json:"cashLetterID"`
@@ -171,9 +171,9 @@ func (clh *CashLetterHeader) Parse(record string) {
 	// 39-42
 	clh.CashLetterCreationTime = clh.parseSimpleTime(record[38:42])
 	// 43-43
-	clh.CashLetterRecordTypeIndicator = clh.parseStringField(record[42:43])
+	clh.RecordTypeIndicator = clh.parseStringField(record[42:43])
 	// 44-44
-	clh.CashLetterDocumentationTypeIndicator = clh.parseStringField(record[43:44])
+	clh.DocumentationTypeIndicator = clh.parseStringField(record[43:44])
 	// 45-52
 	clh.CashLetterID = clh.parseStringField(record[44:52])
 	// 53-66
@@ -201,8 +201,8 @@ func (clh *CashLetterHeader) String() string {
 	buf.WriteString(clh.CashLetterBusinessDateField())
 	buf.WriteString(clh.CashLetterCreationDateField())
 	buf.WriteString(clh.CashLetterCreationTimeField())
-	buf.WriteString(clh.CashLetterRecordTypeIndicatorField())
-	buf.WriteString(clh.CashLetterDocumentationTypeIndicatorField())
+	buf.WriteString(clh.RecordTypeIndicatorField())
+	buf.WriteString(clh.DocumentationTypeIndicatorField())
 	buf.WriteString(clh.CashLetterIDField())
 	buf.WriteString(clh.OriginatorContactNameField())
 	buf.WriteString(clh.OriginatorContactPhoneNumberField())
@@ -229,14 +229,14 @@ func (clh *CashLetterHeader) Validate() error {
 			Value: clh.CollectionTypeIndicator, Msg: err.Error()}
 	}
 	// Mandatory
-	if err := clh.isCashLetterRecordTypeIndicator(clh.CashLetterRecordTypeIndicator); err != nil {
-		return &FieldError{FieldName: "CashLetterRecordTypeIndicator",
-			Value: clh.CashLetterRecordTypeIndicator, Msg: err.Error()}
+	if err := clh.isRecordTypeIndicator(clh.RecordTypeIndicator); err != nil {
+		return &FieldError{FieldName: "RecordTypeIndicator",
+			Value: clh.RecordTypeIndicator, Msg: err.Error()}
 	}
 	// Conditional validator contains ""
-	if err := clh.isDocumentationTypeIndicator(clh.CashLetterDocumentationTypeIndicator); err != nil {
-		return &FieldError{FieldName: "CashLetterDocumentationTypeIndicator",
-			Value: clh.CashLetterDocumentationTypeIndicator, Msg: err.Error()}
+	if err := clh.isDocumentationTypeIndicator(clh.DocumentationTypeIndicator); err != nil {
+		return &FieldError{FieldName: "DocumentationTypeIndicator",
+			Value: clh.DocumentationTypeIndicator, Msg: err.Error()}
 	}
 	if err := clh.isAlphanumeric(clh.CashLetterID); err != nil {
 		return &FieldError{FieldName: "CashLetterID", Value: clh.CashLetterID, Msg: err.Error()}
@@ -270,9 +270,9 @@ func (clh *CashLetterHeader) fieldInclusion() error {
 		return &FieldError{FieldName: "CollectionTypeIndicator",
 			Value: clh.CollectionTypeIndicator, Msg: msgFieldInclusion}
 	}
-	if clh.CashLetterRecordTypeIndicator == "" {
-		return &FieldError{FieldName: "CashLetterRecordTypeIndicator",
-			Value: clh.CashLetterRecordTypeIndicator, Msg: msgFieldInclusion}
+	if clh.RecordTypeIndicator == "" {
+		return &FieldError{FieldName: "RecordTypeIndicator",
+			Value: clh.RecordTypeIndicator, Msg: msgFieldInclusion}
 	}
 	if clh.DestinationRoutingNumber == "" {
 		return &FieldError{FieldName: "DestinationRoutingNumber",
@@ -338,14 +338,14 @@ func (clh *CashLetterHeader) CashLetterCreationTimeField() string {
 	return clh.formatSimpleTime(clh.CashLetterCreationTime)
 }
 
-// CashLetterRecordTypeIndicatorField gets the CashLetterRecordTypeIndicator field
-func (clh *CashLetterHeader) CashLetterRecordTypeIndicatorField() string {
-	return clh.alphaField(clh.CashLetterRecordTypeIndicator, 1)
+// RecordTypeIndicatorField gets the RecordTypeIndicator field
+func (clh *CashLetterHeader) RecordTypeIndicatorField() string {
+	return clh.alphaField(clh.RecordTypeIndicator, 1)
 }
 
-// CashLetterDocumentationTypeIndicatorField gets the CashLetterDocumentationTypeIndicator field
-func (clh *CashLetterHeader) CashLetterDocumentationTypeIndicatorField() string {
-	return clh.alphaField(clh.CashLetterDocumentationTypeIndicator, 1)
+// DocumentationTypeIndicatorField gets the DocumentationTypeIndicator field
+func (clh *CashLetterHeader) DocumentationTypeIndicatorField() string {
+	return clh.alphaField(clh.DocumentationTypeIndicator, 1)
 }
 
 // CashLetterIDField gets the CashLetterID field

--- a/cashLetterHeader_test.go
+++ b/cashLetterHeader_test.go
@@ -20,8 +20,8 @@ func mockCashLetterHeader() *CashLetterHeader {
 	clh.CashLetterBusinessDate = time.Now()
 	clh.CashLetterCreationDate = time.Now()
 	clh.CashLetterCreationTime = time.Now()
-	clh.CashLetterRecordTypeIndicator = "I"
-	clh.CashLetterDocumentationTypeIndicator = "G"
+	clh.RecordTypeIndicator = "I"
+	clh.DocumentationTypeIndicator = "G"
 	clh.CashLetterID = "A1"
 	clh.OriginatorContactName = "Contact Name"
 	clh.OriginatorContactPhoneNumber = "5558675552"
@@ -49,10 +49,10 @@ func TestMockCashLetterHeader(t *testing.T) {
 	if clh.ECEInstitutionRoutingNumber != "121042882" {
 		t.Error("ECEInstitutionRoutingNumber does not validate")
 	}
-	if clh.CashLetterRecordTypeIndicator != "I" {
+	if clh.RecordTypeIndicator != "I" {
 		t.Error("RecordTypeIndicator does not validate")
 	}
-	if clh.CashLetterDocumentationTypeIndicator != "G" {
+	if clh.DocumentationTypeIndicator != "G" {
 		t.Error("DocumentationTypeIndicator does not validate")
 	}
 	if clh.CashLetterID != "A1" {
@@ -110,11 +110,11 @@ func TestParseCashLetterHeader(t *testing.T) {
 	if record.CashLetterCreationTimeField() != "1523" {
 		t.Errorf("CashLetterCreationTime Expected '1523' got:'%v'", record.CashLetterCreationTimeField())
 	}
-	if record.CashLetterRecordTypeIndicatorField() != "I" {
-		t.Errorf("CashLetterRecordTypeIndicator Expected 'I' got: %v", record.CashLetterRecordTypeIndicatorField())
+	if record.RecordTypeIndicatorField() != "I" {
+		t.Errorf("RecordTypeIndicator Expected 'I' got: %v", record.RecordTypeIndicatorField())
 	}
-	if record.CashLetterDocumentationTypeIndicatorField() != "G" {
-		t.Errorf("CashLetterDocumentationTypeIndicator Expected 'G' got:'%v'", record.CashLetterDocumentationTypeIndicatorField())
+	if record.DocumentationTypeIndicatorField() != "G" {
+		t.Errorf("DocumentationTypeIndicator Expected 'G' got:'%v'", record.DocumentationTypeIndicatorField())
 	}
 	if record.CashLetterIDField() != "A1      " {
 		t.Errorf("CashLetterID Expected 'A1      ' got:'%v'", record.CashLetterIDField())
@@ -194,26 +194,26 @@ func TestCHCollectionTypeIndicator(t *testing.T) {
 	}
 }
 
-// TestCashLetterRecordTypeIndicator validation
-func TestCashLetterRecordTypeIndicator(t *testing.T) {
+// TestRecordTypeIndicator validation
+func TestRecordTypeIndicator(t *testing.T) {
 	clh := mockCashLetterHeader()
-	clh.CashLetterRecordTypeIndicator = "W"
+	clh.RecordTypeIndicator = "W"
 	if err := clh.Validate(); err != nil {
 		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CashLetterRecordTypeIndicator" {
+			if e.FieldName != "RecordTypeIndicator" {
 				t.Errorf("%T: %s", err, err)
 			}
 		}
 	}
 }
 
-// TestCashLetterDocumentationTypeIndicator validation
-func TestCashLetterDocumentationTypeIndicator(t *testing.T) {
+// TestDocumentationTypeIndicator validation
+func TestDocumentationTypeIndicator(t *testing.T) {
 	clh := mockCashLetterHeader()
-	clh.CashLetterDocumentationTypeIndicator = "WAZ"
+	clh.DocumentationTypeIndicator = "WAZ"
 	if err := clh.Validate(); err != nil {
 		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CashLetterDocumentationTypeIndicator" {
+			if e.FieldName != "DocumentationTypeIndicator" {
 				t.Errorf("%T: %s", err, err)
 			}
 		}
@@ -324,10 +324,10 @@ func TestFieldInclusionCollectionTypeIndicator(t *testing.T) {
 	}
 }
 
-// TestFieldInclusionCashLetterRecordTypeIndicator validates FieldInclusion
-func TestFieldInclusionCashLetterRecordTypeIndicator(t *testing.T) {
+// TestFieldInclusionRecordTypeIndicator validates FieldInclusion
+func TestFieldInclusionRecordTypeIndicator(t *testing.T) {
 	clh := mockCashLetterHeader()
-	clh.CashLetterRecordTypeIndicator = ""
+	clh.RecordTypeIndicator = ""
 	if err := clh.Validate(); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.Msg != msgFieldInclusion {

--- a/cashLetter_test.go
+++ b/cashLetter_test.go
@@ -1,0 +1,60 @@
+package x9
+
+import (
+	"testing"
+)
+
+// TestCashLetterNoBundle validates no Bundle when CashLetterHeader.RecordTypeIndicator = "N"
+func TestCashLetterNoBundle(t *testing.T) {
+	// Create CheckDetail
+	cd := mockCheckDetail()
+	cd.AddCheckDetailAddendumA(mockCheckDetailAddendumA())
+	cd.AddCheckDetailAddendumB(mockCheckDetailAddendumB())
+	cd.AddCheckDetailAddendumC(mockCheckDetailAddendumC())
+	cd.AddImageViewDetail(mockImageViewDetail())
+	cd.AddImageViewData(mockImageViewData())
+	cd.AddImageViewAnalysis(mockImageViewAnalysis())
+	bundle := NewBundle(mockBundleHeader())
+	bundle.AddCheckDetail(cd)
+
+	// Create CashLetter
+	cl := NewCashLetter(mockCashLetterHeader())
+	cl.GetHeader().RecordTypeIndicator = "N"
+	cl.AddBundle(bundle)
+	if err := cl.Create(); err != nil {
+		if e, ok := err.(*CashLetterError); ok {
+			if e.FieldName != "RecordTypeIndicator" {
+				t.Errorf("%T: %s", err, err)
+			}
+		}
+	}
+}
+
+// TestCashLetterNoRoutingNumberSummary validates no Bundle when CashLetterHeader.CollectionTypeIndicator is not
+// 00, 01, 02
+func TestCashLetterRoutingNumberSummary(t *testing.T) {
+	// Create CheckDetail
+	cd := mockCheckDetail()
+	cd.AddCheckDetailAddendumA(mockCheckDetailAddendumA())
+	cd.AddCheckDetailAddendumB(mockCheckDetailAddendumB())
+	cd.AddCheckDetailAddendumC(mockCheckDetailAddendumC())
+	cd.AddImageViewDetail(mockImageViewDetail())
+	cd.AddImageViewData(mockImageViewData())
+	cd.AddImageViewAnalysis(mockImageViewAnalysis())
+	bundle := NewBundle(mockBundleHeader())
+	bundle.AddCheckDetail(cd)
+
+	// Create CashLetter
+	cl := NewCashLetter(mockCashLetterHeader())
+	cl.GetHeader().CollectionTypeIndicator = "03"
+	cl.AddBundle(bundle)
+	rns := mockRoutingNumberSummary()
+	cl.AddRoutingNumberSummary(rns)
+	if err := cl.Create(); err != nil {
+		if e, ok := err.(*CashLetterError); ok {
+			if e.FieldName != "CollectionTypeIndicator" {
+				t.Errorf("%T: %s", err, err)
+			}
+		}
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -579,8 +579,10 @@ func (r *Reader) parseRoutingNumberSummary() error {
 	if r.currentCashLetter.CashLetterHeader == nil {
 		return r.error(&FileError{Msg: msgFileRoutingNumberSummary})
 	}
-	r.currentCashLetter.currentRoutingNumberSummary.Parse(r.line)
-	if err := r.currentCashLetter.currentRoutingNumberSummary.Validate(); err != nil {
+
+	rns := NewRoutingNumberSummary()
+	rns.Parse(r.line)
+	if err := rns.Validate(); err != nil {
 		return r.error(err)
 	}
 	return nil

--- a/validators.go
+++ b/validators.go
@@ -213,8 +213,8 @@ func (v *validator) isCollectionTypeIndicator(code string) error {
 	return errors.New(msgInvalid)
 }
 
-// isCashLetterRecordTypeIndicator ensures CashLetterRecordTypeIndicator of a CashLetterHeader is valid
-func (v *validator) isCashLetterRecordTypeIndicator(code string) error {
+// isRecordTypeIndicator ensures CashLetterRecordTypeIndicator of a CashLetterHeader is valid
+func (v *validator) isRecordTypeIndicator(code string) error {
 	switch code {
 	case
 		// No electronic check records or image records (Type 2x’s, 3x’s, 5x’s); e.g., an empty cash letter.

--- a/writer.go
+++ b/writer.go
@@ -113,17 +113,6 @@ func (w *Writer) writeBundle(cl CashLetter) error {
 	return nil
 }
 
-// writeRoutingNumberSummary writes a RoutingNumberSummary to a CashLetter
-func (w *Writer) writeRoutingNumberSummary(cl CashLetter) error {
-	for _, rns := range cl.GetRoutingNumberSummary() {
-		if _, err := w.w.WriteString(rns.String() + "\n"); err != nil {
-			return err
-		}
-		w.lineNum++
-	}
-	return nil
-}
-
 // writeCheckDetail writes a CheckDetail to a Bundle
 func (w *Writer) writeCheckDetail(b *Bundle) error {
 	for _, cd := range b.GetChecks() {

--- a/writer_test.go
+++ b/writer_test.go
@@ -6,6 +6,7 @@ package x9
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 )
@@ -176,4 +177,62 @@ func TestX9WriteCreditItem(t *testing.T) {
 	if err = r.File.Validate(); err != nil {
 		t.Errorf("%T: %s", err, err)
 	}
+}
+
+// TestX9WriteRoutingNumberSummary writes an X9 file with a RoutingNumberSummary
+func TestX9WriteRoutingNumber(t *testing.T) {
+	file := NewFile().SetHeader(mockFileHeader())
+
+	// RoutingNumberSummary
+	rns := mockRoutingNumberSummary()
+
+	// Create CheckDetail
+	cd := mockCheckDetail()
+	cd.AddCheckDetailAddendumA(mockCheckDetailAddendumA())
+	cd.AddCheckDetailAddendumB(mockCheckDetailAddendumB())
+	cd.AddCheckDetailAddendumC(mockCheckDetailAddendumC())
+	cd.AddImageViewDetail(mockImageViewDetail())
+	cd.AddImageViewData(mockImageViewData())
+	cd.AddImageViewAnalysis(mockImageViewAnalysis())
+	bundle := NewBundle(mockBundleHeader())
+	bundle.AddCheckDetail(cd)
+
+	// Create CashLetter
+	cl := NewCashLetter(mockCashLetterHeader())
+	cl.AddBundle(bundle)
+	cl.AddRoutingNumberSummary(rns)
+	cl.Create()
+	file.AddCashLetter(cl)
+
+	// Create file
+	if err := file.Create(); err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+	if err := file.Validate(); err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	b := &bytes.Buffer{}
+	f := NewWriter(b)
+
+	if err := f.Write(file); err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	// We want to write the file to an io.Writer
+	w := NewWriter(os.Stdout)
+	/*		if err := w.Write(file); err != nil {
+			log.Fatalf("Unexpected error: %s\n", err)
+		}*/
+	w.Flush()
+
+	r := NewReader(strings.NewReader(b.String()))
+	_, err := r.Read()
+	if err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+	if err = r.File.Validate(); err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+
 }


### PR DESCRIPTION
Added CashLetter Validation logic for RoutingNumberSummary when CashLetterHeader.CollectionTypeIndicator is not 00, 01, 02

Add CreditItem validation logic when CashLetterHeader.RecordTypeIndicator = "N

Some cleanup:

Removed CashLetter from property names RecordTypeIndicator and DocumentationType Indicator.